### PR TITLE
make local file extension optional

### DIFF
--- a/index.js
+++ b/index.js
@@ -79,7 +79,7 @@ function MomentLocalesPlugin(options) {
 
     if (localesToKeep.length > 0) {
         var regExpPatterns = localesToKeep.map(function(localeName) {
-            return localeName + '\\.js';
+            return localeName + '(\\.js)?';
         });
 
         return new ContextReplacementPlugin(

--- a/index.test.js
+++ b/index.test.js
@@ -7,7 +7,7 @@ test('returns a ContextReplacementPlugin instance when locales are passed', () =
 
     expect(result.constructor.name).toEqual('ContextReplacementPlugin');
     expect(result.newContentRegExp.toString()).toEqual(
-        '/(en-gb\\.js|ru\\.js)$/'
+        '/(en-gb(\\.js)?|ru(\\.js)?)$/'
     );
 });
 
@@ -30,7 +30,7 @@ test('normalizes locales to match file names', () => {
         localesToKeep: ['en-gb-foo'],
     });
 
-    expect(result.newContentRegExp.toString()).toMatch(/en-gb\\.js/);
+    expect(result.newContentRegExp.toString()).toMatch(/en-gb(\\.js)?/);
 });
 
 describe('validation', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2293,6 +2293,14 @@
             }
           }
         },
+        "string_decoder": {
+          "version": "1.0.1",
+          "bundled": true,
+          "dev": true,
+          "requires": {
+            "safe-buffer": "5.0.1"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
@@ -2301,14 +2309,6 @@
             "code-point-at": "1.1.0",
             "is-fullwidth-code-point": "1.0.0",
             "strip-ansi": "3.0.1"
-          }
-        },
-        "string_decoder": {
-          "version": "1.0.1",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
           }
         },
         "stringstream": {
@@ -4765,6 +4765,15 @@
         "xtend": "4.0.1"
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "dev": true,
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -4783,15 +4792,6 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {


### PR DESCRIPTION
When the `localesToKeep` option has at least one element the plugin is not filtering out _any_ locales when running webpack 3.x.x and moment 2.9.x and code splitting using CommonsChunkPlugin. This PR makes the `.js` file extension optional and fixes filtering with the above versions. This hasn't been tested using other version combinations.