### PR TITLE
Fix missing locales

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ function MomentLocalesPlugin(options) {
 
     if (localesToKeep.length > 0) {
         var regExpPatterns = localesToKeep.map(function(localeName) {
-            return localeName + '\\.js';
+            return localeName + '(\\.js)?';
         });
 
         return new ContextReplacementPlugin(


### PR DESCRIPTION
According to http://momentjs.com/docs/#/i18n/ , I'm using:
`moment.locale('af')`
After enabling this plugin moment don't see whitelisted locales on my setup. This PR fixes it:

My setup:
```
moment@2.18.1
moment-locales-webpack-plugin@1.05
npm@5.8.0
webpack@3.11
```

Original moment locales map:

```
/***/ "./node_modules/moment/locale recursive ^\\.\\/.*$":
/***/ (function(module, exports, __webpack_require__) {

var map = {
	"./af": "./node_modules/moment/locale/af.js",
	"./af.js": "./node_modules/moment/locale/af.js",
	"./ar": "./node_modules/moment/locale/ar.js",
	"./ar-dz": "./node_modules/moment/locale/ar-dz.js",
	"./ar-dz.js": "./node_modules/moment/locale/ar-dz.js",
...
```

After enabling plugin:
```
/***/ "./node_modules/moment/locale recursive (af\\.js)$":
/***/ (function(module, exports, __webpack_require__) {

var map = {
	"./af.js": "./node_modules/moment/locale/af.js",
};
```

For some reason webpack is trying to load `./af` not `./af.js` in my case. That's why I whitelisted both in the regex.
After my change:
```
/***/ "./node_modules/moment/locale recursive (af(\\.js)?)$":
/***/ (function(module, exports, __webpack_require__) {

var map = {
	"./af": "./node_modules/moment/locale/af.js",
	"./af.js": "./node_modules/moment/locale/af.js",
};
```
