### PR TITLE
feat(plugin-options): adding option to ignore unsupported locales during build

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,12 @@ An array of locales to keep bundled (other locales would be removed).
 
 Locale names follow Moment.js behavior – if a specific locale name (e.g. `ru-ru`) is absent, but a more generic locale (`ru`) is available, the generic one will be kept bundled.
 
+### **`ignoreInvalidLocales: Boolean`**
+
+A flag to ignore invalid or unsupported locales in the `localesToKeep` array.
+
+Be careful! A typo in the `localesToKeep` array with this flag enabled will silently exclude the desired locale from your bundle.
+
 ## Related projects
 
 * [`moment-timezone-data-webpack-plugin`](https://github.com/gilmoreorless/moment-timezone-data-webpack-plugin) – a plugin optimizing the Moment Timezone library.

--- a/package-lock.json
+++ b/package-lock.json
@@ -264,7 +264,6 @@
             "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
             "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
             "dev": true,
-            "optional": true,
             "requires": {
                 "kind-of": "^3.0.2",
                 "longest": "^1.0.1",
@@ -4298,8 +4297,7 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
             "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-            "dev": true,
-            "optional": true
+            "dev": true
         },
         "loose-envify": {
             "version": "1.3.1",
@@ -5915,15 +5913,14 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "co": "4.6.0",
-                                "json-stable-stringify": "1.0.1"
+                                "co": "^4.6.0",
+                                "json-stable-stringify": "^1.0.1"
                             }
                         },
                         "ansi-regex": {
                             "version": "2.1.1",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "aproba": {
                             "version": "1.1.1",
@@ -5937,8 +5934,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "delegates": "1.0.0",
-                                "readable-stream": "2.2.9"
+                                "delegates": "^1.0.0",
+                                "readable-stream": "^2.0.6"
                             }
                         },
                         "asn1": {
@@ -5982,25 +5979,23 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "tweetnacl": "0.14.5"
+                                "tweetnacl": "^0.14.3"
                             }
                         },
                         "block-stream": {
                             "version": "0.0.9",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "inherits": "2.0.3"
+                                "inherits": "~2.0.0"
                             }
                         },
                         "boom": {
                             "version": "2.10.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "hoek": "2.16.3"
+                                "hoek": "2.x.x"
                             }
                         },
                         "brace-expansion": {
@@ -6008,15 +6003,14 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "balanced-match": "0.4.2",
+                                "balanced-match": "^0.4.1",
                                 "concat-map": "0.0.1"
                             }
                         },
                         "buffer-shims": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "caseless": {
                             "version": "0.12.0",
@@ -6033,16 +6027,14 @@
                         "code-point-at": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "combined-stream": {
                             "version": "1.0.5",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "delayed-stream": "1.0.0"
+                                "delayed-stream": "~1.0.0"
                             }
                         },
                         "concat-map": {
@@ -6053,22 +6045,19 @@
                         "console-control-strings": {
                             "version": "1.1.0",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "core-util-is": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "cryptiles": {
                             "version": "2.0.5",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "boom": "2.10.1"
+                                "boom": "2.x.x"
                             }
                         },
                         "dashdash": {
@@ -6077,7 +6066,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "assert-plus": "1.0.0"
+                                "assert-plus": "^1.0.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
@@ -6106,8 +6095,7 @@
                         "delayed-stream": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "delegates": {
                             "version": "1.0.0",
@@ -6127,7 +6115,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "jsbn": "0.1.1"
+                                "jsbn": "~0.1.0"
                             }
                         },
                         "extend": {
@@ -6139,8 +6127,7 @@
                         "extsprintf": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "forever-agent": {
                             "version": "0.6.1",
@@ -6154,9 +6141,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "asynckit": "0.4.0",
-                                "combined-stream": "1.0.5",
-                                "mime-types": "2.1.15"
+                                "asynckit": "^0.4.0",
+                                "combined-stream": "^1.0.5",
+                                "mime-types": "^2.1.12"
                             }
                         },
                         "fs.realpath": {
@@ -6168,7 +6155,6 @@
                             "version": "1.0.11",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "graceful-fs": "^4.1.2",
                                 "inherits": "~2.0.0",
@@ -6193,14 +6179,14 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "aproba": "1.1.1",
-                                "console-control-strings": "1.1.0",
-                                "has-unicode": "2.0.1",
-                                "object-assign": "4.1.1",
-                                "signal-exit": "3.0.2",
-                                "string-width": "1.0.2",
-                                "strip-ansi": "3.0.1",
-                                "wide-align": "1.1.2"
+                                "aproba": "^1.0.3",
+                                "console-control-strings": "^1.0.0",
+                                "has-unicode": "^2.0.0",
+                                "object-assign": "^4.1.0",
+                                "signal-exit": "^3.0.0",
+                                "string-width": "^1.0.1",
+                                "strip-ansi": "^3.0.1",
+                                "wide-align": "^1.1.0"
                             }
                         },
                         "getpass": {
@@ -6209,7 +6195,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "assert-plus": "1.0.0"
+                                "assert-plus": "^1.0.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
@@ -6236,8 +6222,7 @@
                         "graceful-fs": {
                             "version": "4.1.11",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "har-schema": {
                             "version": "1.0.5",
@@ -6251,8 +6236,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "ajv": "4.11.8",
-                                "har-schema": "1.0.5"
+                                "ajv": "^4.9.1",
+                                "har-schema": "^1.0.5"
                             }
                         },
                         "has-unicode": {
@@ -6265,12 +6250,11 @@
                             "version": "3.1.3",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "boom": "2.10.1",
-                                "cryptiles": "2.0.5",
-                                "hoek": "2.16.3",
-                                "sntp": "1.0.9"
+                                "boom": "2.x.x",
+                                "cryptiles": "2.x.x",
+                                "hoek": "2.x.x",
+                                "sntp": "1.x.x"
                             }
                         },
                         "hoek": {
@@ -6284,9 +6268,9 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "assert-plus": "0.2.0",
-                                "jsprim": "1.4.0",
-                                "sshpk": "1.13.0"
+                                "assert-plus": "^0.2.0",
+                                "jsprim": "^1.2.2",
+                                "sshpk": "^1.7.0"
                             }
                         },
                         "inflight": {
@@ -6313,9 +6297,8 @@
                             "version": "1.0.0",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "number-is-nan": "1.0.1"
+                                "number-is-nan": "^1.0.0"
                             }
                         },
                         "is-typedarray": {
@@ -6327,8 +6310,7 @@
                         "isarray": {
                             "version": "1.0.0",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "isstream": {
                             "version": "0.1.2",
@@ -6342,7 +6324,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "jsbn": "0.1.1"
+                                "jsbn": "~0.1.0"
                             }
                         },
                         "jsbn": {
@@ -6363,7 +6345,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "jsonify": "0.0.0"
+                                "jsonify": "~0.0.0"
                             }
                         },
                         "json-stringify-safe": {
@@ -6401,16 +6383,14 @@
                         "mime-db": {
                             "version": "1.27.0",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "mime-types": {
                             "version": "2.1.15",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "mime-db": "1.27.0"
+                                "mime-db": "~1.27.0"
                             }
                         },
                         "minimatch": {
@@ -6418,20 +6398,18 @@
                             "bundled": true,
                             "dev": true,
                             "requires": {
-                                "brace-expansion": "1.1.7"
+                                "brace-expansion": "^1.1.7"
                             }
                         },
                         "minimist": {
                             "version": "0.0.8",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "mkdirp": {
                             "version": "0.5.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "minimist": "0.0.8"
                             }
@@ -6467,8 +6445,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "abbrev": "1.1.0",
-                                "osenv": "0.1.4"
+                                "abbrev": "1",
+                                "osenv": "^0.1.4"
                             }
                         },
                         "npmlog": {
@@ -6486,8 +6464,7 @@
                         "number-is-nan": {
                             "version": "1.0.1",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "oauth-sign": {
                             "version": "0.8.2",
@@ -6527,8 +6504,8 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "os-homedir": "1.0.2",
-                                "os-tmpdir": "1.0.2"
+                                "os-homedir": "^1.0.0",
+                                "os-tmpdir": "^1.0.0"
                             }
                         },
                         "path-is-absolute": {
@@ -6545,8 +6522,7 @@
                         "process-nextick-args": {
                             "version": "1.0.7",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "punycode": {
                             "version": "1.4.1",
@@ -6566,10 +6542,10 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "deep-extend": "0.4.2",
-                                "ini": "1.3.4",
-                                "minimist": "1.2.0",
-                                "strip-json-comments": "2.0.1"
+                                "deep-extend": "~0.4.0",
+                                "ini": "~1.3.0",
+                                "minimist": "^1.2.0",
+                                "strip-json-comments": "~2.0.1"
                             },
                             "dependencies": {
                                 "minimist": {
@@ -6584,15 +6560,14 @@
                             "version": "2.2.9",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "buffer-shims": "1.0.0",
-                                "core-util-is": "1.0.2",
-                                "inherits": "2.0.3",
-                                "isarray": "1.0.0",
-                                "process-nextick-args": "1.0.7",
-                                "string_decoder": "1.0.1",
-                                "util-deprecate": "1.0.2"
+                                "buffer-shims": "~1.0.0",
+                                "core-util-is": "~1.0.0",
+                                "inherits": "~2.0.1",
+                                "isarray": "~1.0.0",
+                                "process-nextick-args": "~1.0.6",
+                                "string_decoder": "~1.0.0",
+                                "util-deprecate": "~1.0.1"
                             }
                         },
                         "request": {
@@ -6601,28 +6576,28 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "aws-sign2": "0.6.0",
-                                "aws4": "1.6.0",
-                                "caseless": "0.12.0",
-                                "combined-stream": "1.0.5",
-                                "extend": "3.0.1",
-                                "forever-agent": "0.6.1",
-                                "form-data": "2.1.4",
-                                "har-validator": "4.2.1",
-                                "hawk": "3.1.3",
-                                "http-signature": "1.1.1",
-                                "is-typedarray": "1.0.0",
-                                "isstream": "0.1.2",
-                                "json-stringify-safe": "5.0.1",
-                                "mime-types": "2.1.15",
-                                "oauth-sign": "0.8.2",
-                                "performance-now": "0.2.0",
-                                "qs": "6.4.0",
-                                "safe-buffer": "5.0.1",
-                                "stringstream": "0.0.5",
-                                "tough-cookie": "2.3.2",
-                                "tunnel-agent": "0.6.0",
-                                "uuid": "3.0.1"
+                                "aws-sign2": "~0.6.0",
+                                "aws4": "^1.2.1",
+                                "caseless": "~0.12.0",
+                                "combined-stream": "~1.0.5",
+                                "extend": "~3.0.0",
+                                "forever-agent": "~0.6.1",
+                                "form-data": "~2.1.1",
+                                "har-validator": "~4.2.1",
+                                "hawk": "~3.1.3",
+                                "http-signature": "~1.1.0",
+                                "is-typedarray": "~1.0.0",
+                                "isstream": "~0.1.2",
+                                "json-stringify-safe": "~5.0.1",
+                                "mime-types": "~2.1.7",
+                                "oauth-sign": "~0.8.1",
+                                "performance-now": "^0.2.0",
+                                "qs": "~6.4.0",
+                                "safe-buffer": "^5.0.1",
+                                "stringstream": "~0.0.4",
+                                "tough-cookie": "~2.3.0",
+                                "tunnel-agent": "^0.6.0",
+                                "uuid": "^3.0.0"
                             }
                         },
                         "rimraf": {
@@ -6636,8 +6611,7 @@
                         "safe-buffer": {
                             "version": "5.0.1",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "semver": {
                             "version": "5.3.0",
@@ -6661,9 +6635,8 @@
                             "version": "1.0.9",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "hoek": "2.16.3"
+                                "hoek": "2.x.x"
                             }
                         },
                         "sshpk": {
@@ -6672,15 +6645,15 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "asn1": "0.2.3",
-                                "assert-plus": "1.0.0",
-                                "bcrypt-pbkdf": "1.0.1",
-                                "dashdash": "1.14.1",
-                                "ecc-jsbn": "0.1.1",
-                                "getpass": "0.1.7",
-                                "jodid25519": "1.0.2",
-                                "jsbn": "0.1.1",
-                                "tweetnacl": "0.14.5"
+                                "asn1": "~0.2.3",
+                                "assert-plus": "^1.0.0",
+                                "bcrypt-pbkdf": "^1.0.0",
+                                "dashdash": "^1.12.0",
+                                "ecc-jsbn": "~0.1.1",
+                                "getpass": "^0.1.1",
+                                "jodid25519": "^1.0.0",
+                                "jsbn": "~0.1.0",
+                                "tweetnacl": "~0.14.0"
                             },
                             "dependencies": {
                                 "assert-plus": {
@@ -6695,20 +6668,18 @@
                             "version": "1.0.2",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "code-point-at": "1.1.0",
-                                "is-fullwidth-code-point": "1.0.0",
-                                "strip-ansi": "3.0.1"
+                                "code-point-at": "^1.0.0",
+                                "is-fullwidth-code-point": "^1.0.0",
+                                "strip-ansi": "^3.0.0"
                             }
                         },
                         "string_decoder": {
                             "version": "1.0.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "safe-buffer": "5.0.1"
+                                "safe-buffer": "^5.0.1"
                             }
                         },
                         "stringstream": {
@@ -6721,9 +6692,8 @@
                             "version": "3.0.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
-                                "ansi-regex": "2.1.1"
+                                "ansi-regex": "^2.0.0"
                             }
                         },
                         "strip-json-comments": {
@@ -6736,7 +6706,6 @@
                             "version": "2.2.1",
                             "bundled": true,
                             "dev": true,
-                            "optional": true,
                             "requires": {
                                 "block-stream": "*",
                                 "fstream": "^1.0.2",
@@ -6765,7 +6734,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "punycode": "1.4.1"
+                                "punycode": "^1.4.1"
                             }
                         },
                         "tunnel-agent": {
@@ -6774,7 +6743,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "safe-buffer": "5.0.1"
+                                "safe-buffer": "^5.0.1"
                             }
                         },
                         "tweetnacl": {
@@ -6792,8 +6761,7 @@
                         "util-deprecate": {
                             "version": "1.0.2",
                             "bundled": true,
-                            "dev": true,
-                            "optional": true
+                            "dev": true
                         },
                         "uuid": {
                             "version": "3.0.1",
@@ -6816,7 +6784,7 @@
                             "dev": true,
                             "optional": true,
                             "requires": {
-                                "string-width": "1.0.2"
+                                "string-width": "^1.0.2"
                             }
                         },
                         "wrappy": {

--- a/test/test.js
+++ b/test/test.js
@@ -103,4 +103,10 @@ describe('validation', () => {
             () => new MomentLocalesPlugin({ localesToKeep: ['foo-bar'] })
         ).toThrow(/Moment.js doesn’t include/);
     });
+
+    test('does not throw when an invalid locale is passed and `ignoreInvalidLocales` is enabled', () => {
+        expect(
+            () => new MomentLocalesPlugin({ localesToKeep: ['foo-bar'], ignoreInvalidLocales: true })
+        ).not.toThrow();
+    });
 });


### PR DESCRIPTION
Hi there! 👋 

I work in UI Infrastructure on a large-scale web application, and we currently have to externalize a custom moment bundle that contains only the locales our application supports. This plugin has been very helpful in doing so!

However, we also have a single source of truth for the supported locales list in our application, and so we have to manually strip out the entries that aren't yet supported in moment so that it plays nicely with this plugin. To help mitigate this problem for future consumers, I have included the following as part of this PR:

1. Added `ignoreInvalidLocales` as an allowed option to the webpack plugin.
2. Refactored the code a little bit to prevent having to duplicate a couple of steps. This mostly consists of the changes around using `localesToKeep.filter(...)` to both compile the `absentLocales` list as well as the appropriate, moment-friendly one.
3. Added the documentation around its use, including a caution to make sure that all locales are spelled correctly when using it.
4. Added a test to validate that it no longer throws the error when the option is used.