### PR TITLE
Make sure validation doesn’t break if there’s an active locale set

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,15 +3,6 @@ var moment = require('moment');
 var IgnorePlugin = require('webpack').IgnorePlugin;
 var ContextReplacementPlugin = require('webpack').ContextReplacementPlugin;
 
-function isModuleAvailable(moduleName) {
-    try {
-        require.resolve(moduleName);
-        return true;
-    } catch (e) {
-        return false;
-    }
-}
-
 function checkOptions(options) {
     var optionsObject = options || {};
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "moment-locales-webpack-plugin",
-    "version": "1.1.0",
+    "version": "1.1.1-0",
     "description": "Strip unused locales from Moment.js",
     "main": "index.js",
     "scripts": {

--- a/test/test.js
+++ b/test/test.js
@@ -105,7 +105,25 @@ describe('validation', () => {
 
     test('does not throw when an invalid locale is passed and `ignoreInvalidLocales` is enabled', () => {
         expect(
-            () => new MomentLocalesPlugin({ localesToKeep: ['foo-bar'], ignoreInvalidLocales: true })
+            () =>
+                new MomentLocalesPlugin({
+                    localesToKeep: ['foo-bar'],
+                    ignoreInvalidLocales: true,
+                })
         ).not.toThrow();
+    });
+
+    // This handles https://github.com/iamakulov/moment-locales-webpack-plugin/issues/23
+    test('does not throw when someone changes the global locale before the build', async () => {
+        const moment = require('moment');
+        moment.locale('de-ch');
+
+        expect(() => {
+            new MomentLocalesPlugin({
+                localesToKeep: ['de-ch'],
+            });
+        }).not.toThrow();
+
+        expect(moment.locale()).toBe('de-ch');
     });
 });

--- a/test/test.js
+++ b/test/test.js
@@ -1,4 +1,3 @@
-const path = require('path');
 const { runWithWebpack } = require('./utils.js');
 const MomentLocalesPlugin = require('../index.js');
 


### PR DESCRIPTION
Fixes #23.

Available in npm as `moment-locales-webpack-plugin@1.1.1-0`.