### PR TITLE
When keeping locales, match full locale names

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ function MomentLocalesPlugin(options) {
 
         return new ContextReplacementPlugin(
             /moment[\/\\]locale/,
-            new RegExp('(' + regExpPatterns.join('|') + ')$')
+            new RegExp('[/\\\\](' + regExpPatterns.join('|') + ')$')
         );
     } else {
         return new IgnorePlugin(/^\.\/locale$/, /moment$/);

--- a/test/test.js
+++ b/test/test.js
@@ -83,6 +83,24 @@ describe('webpack build', () => {
         expect(localeModules).toHaveLength(1);
         expect(localeModules[0]).toMatch('moment/locale/en-gb');
     });
+
+    // Covers https://github.com/iamakulov/moment-locales-webpack-plugin/issues/13
+    test('doesn’t include locales whose names intersect with a passed locale', async () => {
+        const modulePaths = await runWithWebpack({
+            localesToKeep: ['ca'],
+        });
+
+        const momentModule = modulePaths.find(path =>
+            path.includes('moment/moment.js')
+        );
+        expect(momentModule).toBeTruthy();
+
+        const localeModules = modulePaths.filter(path =>
+            path.includes(`moment/locale`)
+        );
+        expect(localeModules).toHaveLength(1);
+        expect(localeModules[0]).toMatch('moment/locale/ca');
+    });
 });
 
 describe('validation', () => {
@@ -106,7 +124,11 @@ describe('validation', () => {
 
     test('does not throw when an invalid locale is passed and `ignoreInvalidLocales` is enabled', () => {
         expect(
-            () => new MomentLocalesPlugin({ localesToKeep: ['foo-bar'], ignoreInvalidLocales: true })
+            () =>
+                new MomentLocalesPlugin({
+                    localesToKeep: ['foo-bar'],
+                    ignoreInvalidLocales: true,
+                })
         ).not.toThrow();
     });
 });


### PR DESCRIPTION
Before this commit, `ContextReplacementPlugin` was configured to only match locale endings. Because of that, if someone used `MomentLocalesPlugin` with e.g. `localesToKeep: ['ca']`, the plugin kept bundled files `ca.js`, `en-ca.js` and `fr-ca.js`.

This PR ensures we match full locale names so no extra locales get bundled.

Closes #13.